### PR TITLE
Flee_to_brazil fixes

### DIFF
--- a/decisions/PortugueseNation.txt
+++ b/decisions/PortugueseNation.txt
@@ -162,7 +162,7 @@ country_decisions = {
 				}					
 			}
 			remove_non_electors_emperors_from_empire_effect = yes
-			every_owned_province = { #this is just a check to make sure that all the siberian colonies of the colonial subject *stay* as siberian colonies (replicated for POB below)
+			every_owned_province = { #this is just a check to make sure that all the siberian colonies of the colonial subject *stay* as siberian colonies
 				limit = {
 				colonial_region = colonial_brazil
 				}

--- a/decisions/PortugueseNation.txt
+++ b/decisions/PortugueseNation.txt
@@ -302,9 +302,9 @@ country_decisions = {
 
 			}
 			if = {
-                limit = { has_custom_ideas = no }
-                country_event = { id = ideagroups.1 } #Swap Ideas
-            }
+                		limit = { has_custom_ideas = no }
+                		country_event = { id = ideagroups.1 } #Swap Ideas
+            		}
 			set_country_flag = changed_from_colonial_nation
 			set_country_flag = fled_to_brazil
 			if ={ limit = {has_country_flag = por_bandeirantes_flag}

--- a/decisions/PortugueseNation.txt
+++ b/decisions/PortugueseNation.txt
@@ -93,5 +93,233 @@ country_decisions = {
 			factor = 1
 		}
 	}
-	
-}
+	por_flee_to_brazil = {
+		major = yes
+		potential = { #colonial subject has 20 provinces, Portugal has <9 in Europe (basically: have you lost anything in portugal)
+			NOT = { has_country_flag = changed_from_colonial_nation }
+			NOT = { has_country_flag = fled_to_brazil }
+			was_never_end_game_tag_trigger = yes
+			is_random_new_world = no
+			normal_or_historical_nations = yes
+			tag = POR
+			government = monarchy
+			any_subject_country = {
+				capital_scope = {
+					colonial_region = colonial_brazil
+				}
+			}
+			NOT = {
+				num_of_owned_provinces_with = {
+					continent = europe
+					value = 9
+				}
+			}
+		}
+		allow = {
+			adm_tech = 10
+			is_free_or_tributary_trigger = yes
+			is_at_war = no
+			custom_trigger_tooltip = {
+				tooltip = brazil_provinces_tooltip
+				any_subject_country = {
+					capital_scope = {
+						colonial_region = colonial_brazil
+					}
+					num_of_cities = 20
+				}
+			}
+		}
+		effect = {
+			change_tag = BRZ
+			on_change_tag_effect = yes
+			every_subject_country = {
+				limit = {
+					capital_scope = {
+						colonial_region = colonial_brazil
+					}
+				}
+				FROM = { inherit = PREV }
+			}
+			custom_tooltip = brazil_move_capital_tooltip
+			hidden_effect = {
+				if = {
+					limit = {
+						763 = {
+							owned_by = ROOT
+						}
+					}
+					763 = {
+						move_capital_effect = yes
+					}
+				}
+				else = {
+					random_owned_province = {
+						limit = {
+							colonial_region = colonial_brazil
+						}
+						move_capital_effect = yes
+					}
+				}					
+			}
+			remove_non_electors_emperors_from_empire_effect = yes
+			every_owned_province = { #this is just a check to make sure that all the siberian colonies of the colonial subject *stay* as siberian colonies (replicated for POB below)
+				limit = {
+				colonial_region = colonial_brazil
+				}
+				if = {
+					limit ={
+						colonysize=950
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 975
+				}
+				else_if = {
+					limit ={
+						colonysize = 900
+					}
+				add_colonysize =-1000
+				add_siberian_construction = 925
+				}
+				else_if = {
+					limit ={
+						colonysize = 850
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 875
+				}
+				else_if = {
+					limit ={
+						colonysize = 800
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 825
+				}
+				else_if = {
+					limit ={
+						colonysize = 750
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 775
+				}
+				else_if = {
+					limit ={
+						colonysize = 700
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 725
+				}
+				else_if = {
+					limit ={
+						colonysize = 650	
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 650
+				}
+				else_if = {
+					limit ={
+						colonysize = 550
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 575
+				}
+				else_if = {
+					limit ={
+						colonysize = 500	
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 525
+				}
+				else_if = {
+					limit ={
+						colonysize = 450
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 475
+				}
+				else_if = {
+					limit ={
+						colonysize = 400
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 425
+				}
+				else_if = {
+					limit ={
+						colonysize = 350
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 375
+				}
+				else_if = {
+					limit ={
+						colonysize = 300
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 325
+				}
+				else_if = {
+					limit ={
+						colonysize = 250
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 275
+				}
+				else_if = {
+					limit ={
+						colonysize = 200
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 225
+				}
+				else_if = {
+					limit ={
+							colonysize = 150	
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 175
+				}
+				else_if = {
+					limit ={
+						colonysize = 100
+					}
+					add_colonysize =-1000
+					add_siberian_construction = 125
+				}
+				else_if = {
+					limit ={
+						colonysize = 50
+					}
+					add_colonysize =-1000
+					add_siberian_construction =75
+				}
+				else_if = {
+					limit ={
+						colonysize = 1
+					}
+					add_colonysize =-1000
+					add_siberian_construction =25
+				}	
+
+			}
+			if = {
+                limit = { has_custom_ideas = no }
+                country_event = { id = ideagroups.1 } #Swap Ideas
+            }
+			set_country_flag = changed_from_colonial_nation
+			set_country_flag = fled_to_brazil
+			if ={ limit = {has_country_flag = por_bandeirantes_flag}
+				765 = { #the modifier in the Portuguese mission tree is not permanent, this re-adds it, easier than modding the Portuguese mission tree
+					add_province_modifier = {
+						name = "por_minas_gerais"
+						duration = -1
+					}
+				}
+			}	
+			ai_will_do = {
+				factor = 1
+			}
+		}
+	}
+
+ }
+


### PR DESCRIPTION
This should fix the (previously) broken "Flee to Brazil!" decision for Portugal, along with some other minor changes.  The decision should:

1. Fix the colonial nation check to instead check for only subject nations in the colonial region (so it works with the mod)
2. Make the owned provinces in Europe check be 9 rather than 5
3. Remove part of the decision that releases Portugal as a PU subject if you're Christian, as this is easy to mostly circumvent in MP and annoying
4. Convert all siberian frontier colonies of colonial Brazil to siberian frontier colonies of Portugal (now, Brazil) to prevent instant bankruptcy or forcing mass-deletion partially complete colonies
5. Add the +2 goods produced modifier to Minas Gerais if Portugal has already taken the gold mining mission (the modifier from the Portuguese missions is not permanent and disappears on ownership-change: this is easier than modifying the Portuguese missions)
6. Remove the -2 stability and -25(?) prestige penalty from the original event